### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ libpng-dev libfreetype6-dev pkg-config gfortran \
 libopenblas-dev liblapack-dev
 ```
 
-2.[PEAR: a fast and accurate Illumina Paired-End reAd mergeR](https://dx.doi.org/10.1093/bioinformatics/btt593)
+2.[PEAR: a fast and accurate Illumina Paired-End reAd mergeR](https://doi.org/10.1093/bioinformatics/btt593)
 
 ```SH
 wget http://sco.h-its.org/exelixis/web/software/pear/files/pear-0.9.10-bin-64.tar.gz

--- a/RnBeads/RnBeads/R/differentialMethylation.R
+++ b/RnBeads/RnBeads/R/differentialMethylation.R
@@ -1500,7 +1500,7 @@ rnb.section.diffMeth.introduction <- function(diffmeth,report){
 	} else if (site.test.method == "refFreeEWAS"){
 		refText <- c(
 			"Houseman, E. A., Molitor, J., and Marsit, C. J. (2014). Reference-Free Cell Mixture Adjustments in Analysis of DNA Methylation Data. ",
-			"<i>Bioinformatics</i>, <a href=http://dx.doi.org/doi:10.1093/bioinformatics/btu029>doi:10.1093/bioinformatics/btu029</a>"
+			"<i>Bioinformatics</i>, <a href=https://doi.org/doi:10.1093/bioinformatics/btu029>doi:10.1093/bioinformatics/btu029</a>"
 		)
 		report <- rnb.add.reference(report, refText)
 

--- a/RnBeads/r-packages/RnBeads/R/differentialMethylation.R
+++ b/RnBeads/r-packages/RnBeads/R/differentialMethylation.R
@@ -1500,7 +1500,7 @@ rnb.section.diffMeth.introduction <- function(diffmeth,report){
 	} else if (site.test.method == "refFreeEWAS"){
 		refText <- c(
 			"Houseman, E. A., Molitor, J., and Marsit, C. J. (2014). Reference-Free Cell Mixture Adjustments in Analysis of DNA Methylation Data. ",
-			"<i>Bioinformatics</i>, <a href=http://dx.doi.org/doi:10.1093/bioinformatics/btu029>doi:10.1093/bioinformatics/btu029</a>"
+			"<i>Bioinformatics</i>, <a href=https://doi.org/doi:10.1093/bioinformatics/btu029>doi:10.1093/bioinformatics/btu029</a>"
 		)
 		report <- rnb.add.reference(report, refText)
 

--- a/docs/_build_html/_sources/index.txt
+++ b/docs/_build_html/_sources/index.txt
@@ -33,4 +33,4 @@ References
 ----------
 
 .. [vanGurp2016] epiGBS: reference-free reduced representation bisulfite sequencing. van Gurp, T. P., Wagemaker, N. C. A. M., Wouters, B. O. R., Vergeer, P., Ouborg, J. N. J., & Verhoeven, K. J. F.
-        Nature Methods, 1–7. http://doi.org/10.1038/nmeth.3763
+        Nature Methods, 1–7. https://doi.org/10.1038/nmeth.3763

--- a/docs/_build_html/index.html
+++ b/docs/_build_html/index.html
@@ -167,7 +167,7 @@ are responsible for reference creation, reference mapping and variant calling an
 <colgroup><col class="label" /><col /></colgroup>
 <tbody valign="top">
 <tr><td class="label">[vanGurp2016]</td><td>epiGBS: reference-free reduced representation bisulfite sequencing. van Gurp, T. P., Wagemaker, N. C. A. M., Wouters, B. O. R., Vergeer, P., Ouborg, J. N. J., &amp; Verhoeven, K. J. F.
-Nature Methods, 1–7. <a class="reference external" href="http://doi.org/10.1038/nmeth.3763">http://doi.org/10.1038/nmeth.3763</a></td></tr>
+Nature Methods, 1–7. <a class="reference external" href="https://doi.org/10.1038/nmeth.3763">https://doi.org/10.1038/nmeth.3763</a></td></tr>
 </tbody>
 </table>
 </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,4 +42,4 @@ References
 ----------
 
 .. [vanGurp2016] epiGBS: reference-free reduced representation bisulfite sequencing. van Gurp, T. P., Wagemaker, N. C. A. M., Wouters, B. O. R., Vergeer, P., Ouborg, J. N. J., & Verhoeven, K. J. F.
-        Nature Methods, 1–7. http://doi.org/10.1038/nmeth.3763
+        Nature Methods, 1–7. https://doi.org/10.1038/nmeth.3763


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!